### PR TITLE
Updating package.json to run foreverJS in npm start & stop scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "socket.io": "^1.4.6"
   },
   "scripts": {
-    "start": "node index.js",
-    "dev": "gulp && node index.js"
+    "start": "forever start index.js",
+    "dev": "gulp && forever start index.js",
+    "stop":  "forever stop index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This commit will add forever as a dependency to run the application
forever using foreverJS (needs to be installed globally)

Fixes #8